### PR TITLE
Add Python Docstring Support

### DIFF
--- a/packages/vscode/themes/common/base.json
+++ b/packages/vscode/themes/common/base.json
@@ -289,6 +289,10 @@
         "punctuation.separator.inheritance.php",
         "punctuation.definition.section.case-statement",
         "string.other.link.description.title.markdown",
+        "string.quoted.docstring.multi",
+        "string.quoted.docstring.multi.python constant.character.escape",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end",
         "string.regexp",
         "variable.language.fenced.markdown"
       ],


### PR DESCRIPTION
Hi,

This is a great theme - awesome work! I've added a few extra scopes which treat Python docstrings as comments, which makes things look even nicer.